### PR TITLE
Upgrade Opta 0.36.0 to fix ODAPI build pipeline

### DIFF
--- a/.github/workflows/opta_deploy.yml
+++ b/.github/workflows/opta_deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Opta tools
         run: |
-          VERSION=0.33.1 /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
+          VERSION=0.36.0 /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
       - name: Set Opta Configuration File Path
         run: |
           echo "OPTA_CONFIG_FILE=wheel-deploys/opta/$ENVIRONMENT/$OPTA_FILE" >> $GITHUB_ENV


### PR DESCRIPTION
ODAPI deployment created with Opta 0.36.0 and the job is pinned to 0.33.1, upgrade to Opta 0.36.0 to fix deployment pipeline (https://github.com/enzyme-health/on-demand-api/actions/runs/3054722799/jobs/4927282363)