### PR TITLE
Fix opta_deploy.yml to point to edge site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Install Opta tools
-        run: VERSION=0.36.0 /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
+        run: VERSION=0.36.0 /bin/bash -c "$(curl -fsSL https://edge.docs.opta.dev/install.sh)"
 
       - uses: azure/setup-kubectl@v2.0
         with:

--- a/.github/workflows/opta_deploy.yml
+++ b/.github/workflows/opta_deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Opta tools
         run: |
-          VERSION=0.36.0 /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
+          VERSION=0.36.0 /bin/bash -c "$(curl -fsSL https://edge.docs.opta.dev/install.sh)"
       - name: Set Opta Configuration File Path
         run: |
           echo "OPTA_CONFIG_FILE=wheel-deploys/opta/$ENVIRONMENT/$OPTA_FILE" >> $GITHUB_ENV


### PR DESCRIPTION
https://docs.opta.dev is down, so using https://edge.docs.opta.dev instead.
