### PR TITLE
fix: Add SUPPRESS_HELM_OUTPUT option to not log output

### DIFF
--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -60,6 +60,11 @@ on:
         type: boolean
         description: 'If true, will not log the helm command output'
         default: false
+      RELEASE_VERSION:
+        required: false
+        type: string
+        description: "Name of the release version to deploy"
+        default: ""
     secrets:
       AWS_ACCOUNT_ACCESS_KEY_ID:
         required: true
@@ -77,7 +82,7 @@ env:
 
 jobs:
   helm-deploy:
-    name: "Helm ${{ inputs.ENVIRONMENT }} Deploy"
+    name: "Helm ${{ inputs.ENVIRONMENT }} Deploy${{ inputs.RELEASE_VERSION && format(' ({0})', inputs.RELEASE_VERSION) || '' }}"
     environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -55,6 +55,11 @@ on:
         type: boolean
         description: "If true, the deployment will not be applied and will run in dry-run mode"
         default: false
+      SUPPRESS_HELM_OUTPUT:
+        required: false
+        type: boolean
+        description: 'If true, will not log the helm command output'
+        default: false
     secrets:
       AWS_ACCOUNT_ACCESS_KEY_ID:
         required: true
@@ -131,7 +136,7 @@ jobs:
           fi
 
           HELM_SET_PARAMS=$(echo "$PARAMS_JSON" | jq -r 'to_entries | .[] | "--set " + .key + "=" + (.value|tostring)' | tr '\n' ' ')
-          
+
           echo "HELM_SET_PARAMS=$HELM_SET_PARAMS" >> $GITHUB_ENV
 
       - name: Run Helm Diff
@@ -152,4 +157,9 @@ jobs:
             $HELM_SET_PARAMS \
             --timeout ${{ inputs.TIMEOUT }}s \
             --atomic \
-            ${{ inputs.TEST_MODE && '--dry-run=server' || '' }}
+            ${{ inputs.TEST_MODE && '--dry-run=server' || '' }} \
+            ${{ inputs.SUPPRESS_HELM_OUTPUT && '> /dev/null' || '' }}
+
+          if [[ "${{ inputs.TEST_MODE }}" == "true" ]]; then
+            echo "Helm dry-run completed successfully"
+          fi

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -166,5 +166,5 @@ jobs:
             ${{ inputs.SUPPRESS_HELM_OUTPUT && '> /dev/null' || '' }}
 
           if [[ "${{ inputs.TEST_MODE }}" == "true" ]]; then
-            echo "Helm dry-run completed successfully"
+            echo "Helm dry-run completed"
           fi


### PR DESCRIPTION
### 📃 Summary
On some ODAPI github workflows, the helm command output may contain sensitive information so we need to add an option to not log the helm command output

### 🔍 Changeset
<!-- List out the code changes introduced by this PR. Data Migrations, Endpoints, etc -->

### 🏷 JIRA Task
<!-- Provide a link to the associated JIRA task. -->

### ↩️ Depends On
<!-- Provide a link to any other PR dependencies. -->

### 📸 Screenshots (before/after)
<!-- If this PR alters any UI, provider before/after screenshots. -->

### 🧪 QA
ODAPI GH Workflow Run in test mode: https://github.com/enzyme-health/on-demand-api/actions/runs/15220749127/job/42815925615

See the logs:
![output-not-logged](https://github.com/user-attachments/assets/45caa771-860a-435b-b842-3e0530bb92d1)


### ✨ Style Guide
[API Style Guide on Confluence](https://wheelhealth.atlassian.net/wiki/spaces/TH/pages/2497871875/Care+API+Code+Style+Guide)

[We're also using eslint/prettier to manage coding styles](https://github.com/heydoctor/eslint-config)

### 📈 Risk Analysis
<!-- Provide a risk description -->

- [ ] Does this affect patients?
- [ ] Does this affect clinical?
- [ ] Does this mutate data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?

### 📝  Documentation Updates
<!-- Do the changes in this PR require any documentation updates or new documentation to be written? -->
