### PR TITLE
PFI-837 feat: option to wait until job complete

### DIFF
--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -65,6 +65,21 @@ on:
         type: string
         description: "Name of the release version to deploy"
         default: ""
+      WAIT_FOR_JOB_COMPLETION:
+        required: false
+        type: boolean
+        description: "If true, will wait for a Kubernetes job to complete after deployment"
+        default: false
+      JOB_NAME:
+        required: false
+        type: string
+        description: "Name of the Kubernetes job to wait for completion (required if WAIT_FOR_JOB_COMPLETION is true)"
+        default: ""
+      JOB_WAIT_TIMEOUT:
+        required: false
+        type: string
+        description: "Timeout in seconds for waiting for job completion"
+        default: "1800"
     secrets:
       AWS_ACCOUNT_ACCESS_KEY_ID:
         required: true
@@ -168,3 +183,12 @@ jobs:
           if [[ "${{ inputs.TEST_MODE }}" == "true" ]]; then
             echo "Helm dry-run completed successfully"
           fi
+
+      - name: Wait for job completion
+        if: ${{ inputs.WAIT_FOR_JOB_COMPLETION && !inputs.TEST_MODE }}
+        run: |
+          echo "Waiting for job '${{ inputs.JOB_NAME }}' to complete..."
+          kubectl wait --for=condition=complete job/${{ inputs.JOB_NAME }} \
+            --timeout=${{ inputs.JOB_WAIT_TIMEOUT }}s \
+            ${{ inputs.USE_HELM_CLI_NAMESPACE && format('--namespace {0}', inputs.HELM_RELEASE_NAMESPACE) || '' }}
+          echo "Job '${{ inputs.JOB_NAME }}' completed successfully"

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -188,7 +188,27 @@ jobs:
         if: ${{ inputs.WAIT_FOR_JOB_COMPLETION && !inputs.TEST_MODE }}
         run: |
           echo "Waiting for job '${{ inputs.JOB_NAME }}' to complete..."
-          kubectl wait --for=condition=complete job/${{ inputs.JOB_NAME }} \
-            --timeout=${{ inputs.JOB_WAIT_TIMEOUT }}s \
-            ${{ inputs.USE_HELM_CLI_NAMESPACE && format('--namespace {0}', inputs.HELM_RELEASE_NAMESPACE) || '' }}
-          echo "Job '${{ inputs.JOB_NAME }}' completed successfully"
+
+          # Set timeout and namespace variables
+          JOB_RESOURCE_NAME=job/${{ inputs.JOB_NAME }}
+          TIMEOUT_SECONDS=${{ inputs.JOB_WAIT_TIMEOUT }}
+          NAMESPACE_FLAG="${{ inputs.USE_HELM_CLI_NAMESPACE && format('--namespace {0}', inputs.HELM_RELEASE_NAMESPACE) || '' }}"
+
+          # Wait for job completion with timeout handling
+          if kubectl wait --for=condition=complete ${JOB_RESOURCE_NAME} \
+            --timeout=${TIMEOUT_SECONDS}s \
+            ${NAMESPACE_FLAG}; then
+            echo "Job '${{ inputs.JOB_NAME }}' completed successfully"
+          else
+            echo "Job '${{ inputs.JOB_NAME }}' did not complete within ${TIMEOUT_SECONDS} seconds"
+            echo "Checking job status..."
+
+            # Get job status
+            kubectl describe ${JOB_RESOURCE_NAME} ${NAMESPACE_FLAG} || true
+
+            echo "Cleaning up timed-out job '${{ inputs.JOB_NAME }}'..."
+            kubectl delete ${JOB_RESOURCE_NAME} ${NAMESPACE_FLAG} --ignore-not-found=true
+
+            echo "Job cleanup completed"
+            exit 1
+          fi

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -114,7 +114,7 @@ jobs:
           repository: enzyme-health/wheel-deploys
           token: ${{ secrets.PAT }}
           path: wheel-deploys
-          ref: migration/opta-deploy
+          ref: main
 
       - name: Install Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -114,7 +114,7 @@ jobs:
           repository: enzyme-health/wheel-deploys
           token: ${{ secrets.PAT }}
           path: wheel-deploys
-          ref: main
+          ref: migration/opta-deploy
 
       - name: Install Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -201,10 +201,6 @@ jobs:
             echo "Job '${{ inputs.JOB_NAME }}' completed successfully"
           else
             echo "Job '${{ inputs.JOB_NAME }}' did not complete within ${TIMEOUT_SECONDS} seconds"
-            echo "Checking job status..."
-
-            # Get job status
-            kubectl describe ${JOB_RESOURCE_NAME} ${NAMESPACE_FLAG} || true
 
             echo "Cleaning up timed-out job '${{ inputs.JOB_NAME }}'..."
             kubectl delete ${JOB_RESOURCE_NAME} ${NAMESPACE_FLAG} --ignore-not-found=true

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -202,9 +202,9 @@ jobs:
           else
             echo "Job '${{ inputs.JOB_NAME }}' did not complete within ${TIMEOUT_SECONDS} seconds"
 
-            echo "Cleaning up timed-out job '${{ inputs.JOB_NAME }}'..."
-            kubectl delete ${JOB_RESOURCE_NAME} ${NAMESPACE_FLAG} --ignore-not-found=true
+            # echo "Cleaning up timed-out job '${{ inputs.JOB_NAME }}'..."
+            # kubectl delete ${JOB_RESOURCE_NAME} ${NAMESPACE_FLAG} --ignore-not-found=true
 
-            echo "Job cleanup completed"
+            # echo "Job cleanup completed"
             exit 1
           fi


### PR DESCRIPTION
### 📃 Summary
<!-- Enter a short description about what this PR contains. -->
In case of DB migration that use job, we need to wait until the job are complete to make sure the helm upgrade are indeed successfull.

### 🔍 Changeset
<!-- List out the code changes introduced by this PR. Data Migrations, Endpoints, etc -->
add new inputs on helm-deploy
- WAIT_FOR_JOB_COMPLETION
- JOB_NAME
- JOB_WAIT_TIMEOUT

### 🏷 JIRA Task
<!-- Provide a link to the associated JIRA task. -->
https://wheelhealth.atlassian.net/browse/PFI-837

### ↩️ Depends On
<!-- Provide a link to any other PR dependencies. -->

### 📸 Screenshots (before/after)
<!-- If this PR alters any UI, provider before/after screenshots. -->

### 🧪 QA
<!-- List out the steps to test the feature. -->
- [x] Change `wheel-deploys` ref to `migration/opta-deploy` branch. 
- [x] Use `feat/workflow-to-wait-job-finished` branch for `enzyme-health/devops.github-actions` usage in downstream services (e.g on-demand-api)
- [x] Revert back `wheel-deploys` ref to `main` branch

### ✨ Style Guide
[API Style Guide on Confluence](https://wheelhealth.atlassian.net/wiki/spaces/TH/pages/2497871875/Care+API+Code+Style+Guide)

[We're also using eslint/prettier to manage coding styles](https://github.com/heydoctor/eslint-config)

### 📈 Risk Analysis
<!-- Provide a risk description -->

- [ ] Does this affect patients?
- [ ] Does this affect clinical?
- [ ] Does this mutate data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?

### 📝  Documentation Updates
<!-- Do the changes in this PR require any documentation updates or new documentation to be written? -->

---

### 📣 Additional Consideration: Slack Notification for Failed Jobs

We may want to add Slack notifications for failed jobs during deployment, similar to what is implemented in [`heydoctor/api`](https://github.com/heydoctor/api/blob/c222c839a71d59f4584ef9d27bd87a0128659d4f/.github/workflows/unified-deploy.yaml#L225-L240).

This would require additional manual configuration
- Adding a `SLACK_WEBHOOK_URL` secret to each service repository's secret configuration.

**Pros:**
- Improves visibility for failed deployments.
- Allows us to remove the logic that automatically deletes timed-out jobs, making failures more explicit and traceable.