### PR TITLE
CDO-19: bump Node 20 actions in helm_deploy.yml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5

--- a/.github/workflows/helm_deploy.yml
+++ b/.github/workflows/helm_deploy.yml
@@ -102,14 +102,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCOUNT_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCOUNT_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
       - name: Checkout repo wheel-deploys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: enzyme-health/wheel-deploys
           token: ${{ secrets.PAT }}
@@ -117,7 +117,7 @@ jobs:
           ref: main
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5
         with:
           version: "v3.17.3"
 


### PR DESCRIPTION
### 📜 JIRA Task
[CDO-19: Bump Node 20 actions in helm_deploy.yml](https://wheelhealth.atlassian.net/browse/CDO-19)

### 🌺 Summary
GitHub flipped the runner default to Node 24 on **2026-06-02** (today) and removes Node 20 entirely on **2026-09-16**. Bumps the three Node 20 actions in the shared `helm_deploy.yml` reusable workflow to their lowest Node 24–compatible majors, so consumers (noria and any others) don't start failing in September.

- `actions/checkout`: `v4` → `v5` ([Node 24 release](https://github.com/actions/checkout/releases/tag/v5.0.0))
- `aws-actions/configure-aws-credentials`: `v4` → `v6` ([Node 24 release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0))
- `azure/setup-helm`: `v3` → `v5` ([Node 24 release](https://github.com/Azure/setup-helm/releases/tag/v5.0.0))
  - The ticket suggested `v4`, but `v4` is still Node 20; `v5` is the first Node 24 line.

Also adds `.github/dependabot.yaml` with a `github-actions` ecosystem block so future runtime deprecations show up as auto-PRs (pattern adopted from noria [PR #790](https://github.com/enzyme-health/noria/pull/790)).

Surfaced via the smoke test under [CDO-9](https://wheelhealth.atlassian.net/browse/CDO-9).

Out of scope: `deploy.yml` and `opta_deploy.yml` in this repo still pin even older Node 16 actions (`configure-aws-credentials@v1`, `checkout@v2`) and target the removed `ubuntu-20.04` runner. Separate follow-ups if those are still used.

### 🧪 Test Steps
**Verified ✅** — see smoke-test comment below for full results.

1. ✅ On noria branch [`cdo-19/smoke-test-node24-bumps`](https://github.com/enzyme-health/noria/tree/cdo-19/smoke-test-node24-bumps), pinned `helm_deploy.yml@main` → `@cdo-19-bump-node20-actions` in `deploy-branch.yaml`.
2. ✅ Ran [Deploy Branch #26820650601](https://github.com/enzyme-health/noria/actions/runs/26820650601) with `test_mode: true` against **sandbox** — all jobs green.
3. ✅ Log-scan of both helm-deploy jobs for `node 20` / `node20` / `deprecat`: zero matches.
4. Post-merge: delete the noria smoke-test branch.

To reproduce on a different consumer: temporarily change `uses: enzyme-health/devops.github-actions/.github/workflows/helm_deploy.yml@main` → `@cdo-19-bump-node20-actions` in your repo's deploy workflow, run it against sandbox in test_mode, and confirm no Node 20 deprecation annotations.

### 📸 Screenshots / Video
N/A — reusable workflow change with no UI surface. Verification artifact is the [GitHub Actions run](https://github.com/enzyme-health/noria/actions/runs/26820650601) linked above.

### 📈 Risk Analysis
Low-risk: pure runtime version bumps on three well-maintained marketplace actions used in our deploy path. Failure mode would be a deploy job breaking, which was caught (and confirmed clear) by the sandbox `test_mode` smoke test before merge. No data path or runtime app behavior changes.

- [ ] Does this affect patients?
- [ ] Does this affect clinical?
- [ ] Does this mutate production data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?

### 📝  Documentation Updates
None required. The reusable workflow's public interface (inputs/secrets/outputs) is unchanged.

[CDO-9]: https://wheelhealth.atlassian.net/browse/CDO-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ